### PR TITLE
make durability configurable

### DIFF
--- a/samples/Subscriber/Subscriber/appsettings.json
+++ b/samples/Subscriber/Subscriber/appsettings.json
@@ -15,6 +15,8 @@
     "Username": "your_username",
     "Password": "your_password",
     "Host": "your_host",
+    "DurableExchange": false,
+    "DurableQueue": true,
     "DispatchConsumersAsync": true
   }
 }

--- a/src/EventBus.RabbitMQ.Standard/Configuration/Registration.cs
+++ b/src/EventBus.RabbitMQ.Standard/Configuration/Registration.cs
@@ -29,7 +29,9 @@ namespace EventBus.RabbitMQ.Standard.Configuration
                     eventBusSubscriptionsManager,
                     brokerName,
                     queueName,
-                    retryCount);
+                    retryCount,
+                    options.DurableExchange,
+                    options.DurableQueue);
             });
 
             services.AddSingleton<IEventBusSubscriptionManager, InMemoryEventBusSubscriptionManager>();

--- a/src/EventBus.RabbitMQ.Standard/Options/RabbitMqOptions.cs
+++ b/src/EventBus.RabbitMQ.Standard/Options/RabbitMqOptions.cs
@@ -9,7 +9,8 @@
         public string RetryCount { get; set; }
         public string Username { get; set; }
         public string VirtualHost { get; set; }
-
+        public bool DurableExchange { get; set; }
+        public bool DurableQueue { get; set; } = true;
         public bool DispatchConsumersAsync { get; set; }
     }
 }


### PR DESCRIPTION
We would like to make the exchange durable and sometimes the queue should be non-durable.

This allows the dev to control the exchange and queue so it can survive rabbitmq restart.

Another way to fix this is to listen for when the message is non routable and correctly allow the developer to bind the queue to the new exchange after a reboot of rabbitmq though that would require a need for calling `DoInternalSubscription` to correctly call `channel.QueueBind` once again.